### PR TITLE
Refactor(#63): 멤버 프로필 이미지 최대 길이 50->512로 수정

### DIFF
--- a/src/main/java/com/example/poppop/domain/member/entity/Member.java
+++ b/src/main/java/com/example/poppop/domain/member/entity/Member.java
@@ -19,7 +19,7 @@ public class Member extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "profile_url", length = 50)
+    @Column(name = "profile_url", length = 512)
     private String profileUrl;
 
     @Column(length = 50, nullable = false)

--- a/src/main/java/com/example/poppop/domain/mypage/dto/request/ProfileUpdateRequest.java
+++ b/src/main/java/com/example/poppop/domain/mypage/dto/request/ProfileUpdateRequest.java
@@ -1,11 +1,11 @@
 package com.example.poppop.domain.mypage.dto.request;
 
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.multipart.MultipartFile;
 
 public record ProfileUpdateRequest(
 
-        MultipartFile profileImage,
+        @RequestParam(value = "profileImage", required = false) MultipartFile profileImage,
         @Size(max = 30) String userName
 ) {}


### PR DESCRIPTION
## 이슈
- #63 

## 🔘Part

- [x] BE

  <br/>

## 🔎 작업 내용

- 멤버 프로필 이미지 url 최대 길이 50-> 512로 수정 

- 멤버 프로필 이미지 수정 시 빈값 가능하도록 수정

  <br/>
